### PR TITLE
Special methods

### DIFF
--- a/discord/audit_logs.py
+++ b/discord/audit_logs.py
@@ -330,6 +330,10 @@ class AuditLogEntry(Hashable):
 
             Returns the entry's hash.
 
+        .. describe:: int(x)
+
+            Returns the entry's ID.
+
     .. versionchanged:: 1.7
         Audit log entries are now comparable and hashable.
 

--- a/discord/channel.py
+++ b/discord/channel.py
@@ -115,6 +115,10 @@ class TextChannel(discord.abc.Messageable, discord.abc.GuildChannel, Hashable):
 
             Returns the channel's name.
 
+        .. describe:: int(x)
+
+            Returns the channel's ID.
+
     Attributes
     -----------
     name: :class:`str`
@@ -1334,6 +1338,10 @@ class CategoryChannel(discord.abc.GuildChannel, Hashable):
 
             Returns the category's name.
 
+        .. describe:: int(x)
+
+            Returns the category's ID.
+
     Attributes
     -----------
     name: :class:`str`
@@ -1556,6 +1564,10 @@ class StoreChannel(discord.abc.GuildChannel, Hashable):
 
             Returns the channel's name.
 
+        .. describe:: int(x)
+
+            Returns the channel's ID.
+
     Attributes
     -----------
     name: :class:`str`
@@ -1728,6 +1740,10 @@ class DMChannel(discord.abc.Messageable, Hashable):
 
             Returns a string representation of the channel
 
+        .. describe:: int(x)
+
+            Returns the channel's ID.
+
     Attributes
     ----------
     recipient: Optional[:class:`User`]
@@ -1853,6 +1869,10 @@ class GroupChannel(discord.abc.Messageable, Hashable):
         .. describe:: str(x)
 
             Returns a string representation of the channel
+
+        .. describe:: int(x)
+
+            Returns the channel's ID.
 
     Attributes
     ----------
@@ -1999,6 +2019,10 @@ class PartialMessageable(discord.abc.Messageable, Hashable):
         .. describe:: hash(x)
 
             Returns the partial messageable's hash.
+
+        .. describe:: int(x)
+
+            Returns the messageable's ID.
 
     Attributes
     -----------

--- a/discord/emoji.py
+++ b/discord/emoji.py
@@ -72,6 +72,10 @@ class Emoji(_EmojiTag, AssetMixin):
 
             Returns the emoji rendered for discord.
 
+        .. describe:: int(x)
+
+            Returns the emoji ID.
+
     Attributes
     -----------
     name: :class:`str`
@@ -136,6 +140,9 @@ class Emoji(_EmojiTag, AssetMixin):
         if self.animated:
             return f'<a:{self.name}:{self.id}>'
         return f'<:{self.name}:{self.id}>'
+
+    def __int__(self) -> int:
+        return self.id
 
     def __repr__(self) -> str:
         return f'<Emoji id={self.id} name={self.name!r} animated={self.animated} managed={self.managed}>'

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -339,9 +339,6 @@ class Guild(Hashable):
     def __str__(self) -> str:
         return self.name or ''
 
-    def __int__(self) -> int:
-        return self.id
-
     def __repr__(self) -> str:
         attrs = (
             ('id', self.id),

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -140,6 +140,10 @@ class Guild(Hashable):
 
             Returns the guild's name.
 
+        .. describe:: int(x)
+
+            Returns the guild's ID.
+
     Attributes
     ----------
     name: :class:`str`
@@ -334,6 +338,9 @@ class Guild(Hashable):
 
     def __str__(self) -> str:
         return self.name or ''
+
+    def __int__(self) -> int:
+        return self.id
 
     def __repr__(self) -> str:
         attrs = (

--- a/discord/invite.py
+++ b/discord/invite.py
@@ -230,6 +230,7 @@ class Invite(Hashable):
 
             Returns the invite URL.
 
+
     The following table illustrates what methods will obtain the attributes:
 
     +------------------------------------+------------------------------------------------------------+
@@ -432,6 +433,9 @@ class Invite(Hashable):
 
     def __str__(self) -> str:
         return self.url
+
+    def __int__(self) -> int:
+        return 0  # To keep the object compatible with the hashable abc.
 
     def __repr__(self) -> str:
         return (

--- a/discord/member.py
+++ b/discord/member.py
@@ -226,6 +226,10 @@ class Member(discord.abc.Messageable, _UserTag):
 
             Returns the member's name with the discriminator.
 
+        .. describe:: int(x)
+
+            Returns the user's ID.
+
     Attributes
     ----------
     joined_at: Optional[:class:`datetime.datetime`]
@@ -299,6 +303,9 @@ class Member(discord.abc.Messageable, _UserTag):
 
     def __str__(self) -> str:
         return str(self._user)
+
+    def __int__(self) -> int:
+        return self.id
 
     def __repr__(self) -> str:
         return (

--- a/discord/message.py
+++ b/discord/message.py
@@ -503,6 +503,14 @@ class Message(Hashable):
 
             Returns the message's hash.
 
+        .. describe:: str(x)
+
+            Returns the message's content.
+
+        .. describe:: int(x)
+
+            Returns the message's ID.
+
     Attributes
     -----------
     tts: :class:`bool`
@@ -711,6 +719,12 @@ class Message(Hashable):
         return (
             f'<{name} id={self.id} channel={self.channel!r} type={self.type!r} author={self.author!r} flags={self.flags!r}>'
         )
+
+    def __int__(self) -> int:
+        return self.id
+
+    def __str__(self) -> Optional[str]:
+        return self.content
 
     def _try_patch(self, data, key, transform=None) -> None:
         try:

--- a/discord/message.py
+++ b/discord/message.py
@@ -125,6 +125,10 @@ class Attachment(Hashable):
 
             Returns the hash of the attachment.
 
+        .. describe:: int(x)
+
+            Returns the attachment's ID.
+
     .. versionchanged:: 1.7
         Attachment can now be casted to :class:`str` and is hashable.
 
@@ -720,8 +724,6 @@ class Message(Hashable):
             f'<{name} id={self.id} channel={self.channel!r} type={self.type!r} author={self.author!r} flags={self.flags!r}>'
         )
 
-    def __int__(self) -> int:
-        return self.id
 
     def __str__(self) -> Optional[str]:
         return self.content
@@ -1638,6 +1640,10 @@ class PartialMessage(Hashable):
         .. describe:: hash(x)
 
             Returns the partial message's hash.
+
+        .. describe:: int(x)
+
+            Returns the partial message's ID.
 
     Attributes
     -----------

--- a/discord/mixins.py
+++ b/discord/mixins.py
@@ -43,5 +43,8 @@ class EqualityComparable:
 class Hashable(EqualityComparable):
     __slots__ = ()
 
+    def __int__(self) -> int:
+        return self.id
+
     def __hash__(self) -> int:
         return self.id >> 22

--- a/discord/object.py
+++ b/discord/object.py
@@ -69,6 +69,10 @@ class Object(Hashable):
 
             Returns the object's hash.
 
+        .. describe:: int(x)
+
+            Returns the object's ID.
+
     Attributes
     -----------
     id: :class:`int`

--- a/discord/role.py
+++ b/discord/role.py
@@ -141,6 +141,10 @@ class Role(Hashable):
 
             Returns the role's name.
 
+        .. describe:: str(x)
+
+            Returns the role's ID.
+
     Attributes
     ----------
     id: :class:`int`
@@ -194,6 +198,9 @@ class Role(Hashable):
 
     def __str__(self) -> str:
         return self.name
+
+    def __int__(self) -> int:
+        return self.id
 
     def __repr__(self) -> str:
         return f'<Role id={self.id} name={self.name!r}>'

--- a/discord/role.py
+++ b/discord/role.py
@@ -145,6 +145,10 @@ class Role(Hashable):
 
             Returns the role's ID.
 
+        .. describe:: int(x)
+
+            Returns the role's ID.
+
     Attributes
     ----------
     id: :class:`int`

--- a/discord/stage_instance.py
+++ b/discord/stage_instance.py
@@ -61,6 +61,10 @@ class StageInstance(Hashable):
 
             Returns the stage instance's hash.
 
+        .. describe:: int(x)
+
+            Returns the stage instance's ID.
+
     Attributes
     -----------
     id: :class:`int`

--- a/discord/sticker.py
+++ b/discord/sticker.py
@@ -67,6 +67,14 @@ class StickerPack(Hashable):
 
             Returns the name of the sticker pack.
 
+        .. describe:: hash(x)
+
+            Returns the hash of the sticker pack.
+
+        .. describe:: int(x)
+
+            Returns the ID of the sticker pack.
+
         .. describe:: x == y
 
            Checks if the sticker pack is equal to another sticker pack.

--- a/discord/threads.py
+++ b/discord/threads.py
@@ -74,6 +74,10 @@ class Thread(Messageable, Hashable):
 
             Returns the thread's hash.
 
+        .. describe:: int(x)
+
+            Returns the thread's ID.
+
         .. describe:: str(x)
 
             Returns the thread's name.
@@ -747,6 +751,10 @@ class ThreadMember(Hashable):
         .. describe:: hash(x)
 
             Returns the thread member's hash.
+
+        .. describe:: int(x)
+
+            Returns the thread member's ID.
 
         .. describe:: str(x)
 

--- a/discord/user.py
+++ b/discord/user.py
@@ -96,6 +96,9 @@ class BaseUser(_UserTag):
     def __str__(self) -> str:
         return f'{self.name}#{self.discriminator}'
 
+    def __int__(self) -> int:
+        return self.id
+
     def __eq__(self, other: Any) -> bool:
         return isinstance(other, _UserTag) and other.id == self.id
 
@@ -414,6 +417,10 @@ class User(BaseUser, discord.abc.Messageable):
         .. describe:: str(x)
 
             Returns the user's name with discriminator.
+
+        .. describe:: int(x)
+
+            Returns the user's ID.
 
     Attributes
     -----------

--- a/discord/webhook/async_.py
+++ b/discord/webhook/async_.py
@@ -886,6 +886,10 @@ class Webhook(BaseWebhook):
 
             Returns the webhooks's hash.
 
+        .. describe:: int(x)
+
+            Returns the webhooks's ID.
+
     .. versionchanged:: 1.4
         Webhooks are now comparable and hashable.
 

--- a/discord/webhook/sync.py
+++ b/discord/webhook/sync.py
@@ -475,6 +475,10 @@ class SyncWebhook(BaseWebhook):
 
             Returns the webhooks's hash.
 
+        .. describe:: int(x)
+
+            Returns the webhooks's ID.
+
     .. versionchanged:: 1.4
         Webhooks are now comparable and hashable.
 


### PR DESCRIPTION
Make a lot, if not all, objects that support `.id` also support `int(object)`. Also makes str(message) returns the message content.