### PR TITLE
Remove intents.default and make intents a required parameter

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -142,7 +142,6 @@ class Client:
     intents: :class:`Intents`
         The intents that you want to enable for the session. This is a way of
         disabling and enabling certain gateway events from triggering and being sent.
-        If not given, defaults to a regularly constructed :class:`Intents` class.
 
         .. versionadded:: 1.5
     member_cache_flags: :class:`MemberCacheFlags`
@@ -203,9 +202,12 @@ class Client:
     def __init__(
         self,
         *,
+        intents: Intents,
         loop: Optional[asyncio.AbstractEventLoop] = None,
         **options: Any,
     ):
+        options["intents"] = intents
+
         # self.ws is set in the connect method
         self.ws: DiscordWebSocket = None  # type: ignore
         self.loop: asyncio.AbstractEventLoop = asyncio.get_event_loop() if loop is None else loop

--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -120,8 +120,8 @@ class _DefaultRepr:
 _default = _DefaultRepr()
 
 class BotBase(GroupMixin):
-    def __init__(self, command_prefix, help_command=_default, description=None, **options):
-        super().__init__(**options)
+    def __init__(self, command_prefix, help_command=_default, description=None, *, intents: discord.Intents, **options):
+        super().__init__(**options, intents=intents)
         self.command_prefix = command_prefix
         self.extra_events: Dict[str, List[CoroFunc]] = {}
         self.__cogs: Dict[str, Cog] = {}

--- a/discord/flags.py
+++ b/discord/flags.py
@@ -480,16 +480,6 @@ class Intents(BaseFlags):
         self.value = self.DEFAULT_VALUE
         return self
 
-    @classmethod
-    def default(cls: Type[Intents]) -> Intents:
-        """A factory method that creates a :class:`Intents` with everything enabled
-        except :attr:`presences` and :attr:`members`.
-        """
-        self = cls.all()
-        self.presences = False
-        self.members = False
-        return self
-
     @flag_value
     def guilds(self):
         """:class:`bool`: Whether guild related events are enabled.

--- a/discord/state.py
+++ b/discord/state.py
@@ -152,6 +152,7 @@ class ConnectionState:
         handlers: Dict[str, Callable],
         hooks: Dict[str, Callable],
         http: HTTPClient,
+        intents: Intents,
         loop: asyncio.AbstractEventLoop,
         **options: Any,
     ) -> None:
@@ -194,12 +195,8 @@ class ConnectionState:
             else:
                 status = str(status)
 
-        intents = options.get('intents', None)
-        if intents is not None:
-            if not isinstance(intents, Intents):
-                raise TypeError(f'intents parameter must be Intent not {type(intents)!r}')
-        else:
-            intents = Intents.default()
+        if not isinstance(intents, Intents):
+            raise TypeError(f'intents parameter must be Intent not {type(intents)!r}')
 
         if not intents.guilds:
             _log.warning('Guilds intent seems to be disabled. This may cause state related issues.')

--- a/examples/background_task.py
+++ b/examples/background_task.py
@@ -26,5 +26,5 @@ class MyClient(discord.Client):
     async def before_my_task(self):
         await self.wait_until_ready() # wait until the bot logs in
 
-client = MyClient()
+client = MyClient(intents=discord.Intents(guilds=True))
 client.run('token')

--- a/examples/background_task_asyncio.py
+++ b/examples/background_task_asyncio.py
@@ -22,5 +22,5 @@ class MyClient(discord.Client):
             await asyncio.sleep(60) # task runs every 60 seconds
 
 
-client = MyClient()
+client = MyClient(intents=discord.Intents(guilds=True))
 client.run('token')

--- a/examples/basic_bot.py
+++ b/examples/basic_bot.py
@@ -9,10 +9,8 @@ module.
 
 There are a number of utility commands being showcased here.'''
 
-intents = discord.Intents.default()
-intents.members = True
-
-bot = commands.Bot(command_prefix='?', description=description, intents=intents)
+intents = discord.Intents(guilds=True, messages=True, members=True)
+bot = commands.Bot(command_prefix='t-', description=description, intents=intents)
 
 @bot.event
 async def on_ready():

--- a/examples/basic_voice.py
+++ b/examples/basic_voice.py
@@ -123,8 +123,11 @@ class Music(commands.Cog):
         elif ctx.voice_client.is_playing():
             ctx.voice_client.stop()
 
-bot = commands.Bot(command_prefix=commands.when_mentioned_or("!"),
-                   description='Relatively simple music bot example')
+bot = commands.Bot(
+    command_prefix=commands.when_mentioned_or("!"),
+    description='Relatively simple music bot example',
+    intents=discord.Intents(guilds=True, guild_messages=True, voice_states=True)
+)
 
 @bot.event
 async def on_ready():

--- a/examples/converters.py
+++ b/examples/converters.py
@@ -5,9 +5,8 @@ import typing
 import discord
 from discord.ext import commands
 
-intents = discord.Intents.default()
-intents.members = True
 
+intents = discord.Intents(guilds=True, messages=True, members=True)
 bot = commands.Bot('!', intents=intents)
 
 

--- a/examples/custom_context.py
+++ b/examples/custom_context.py
@@ -29,7 +29,7 @@ class MyBot(commands.Bot):
         return await super().get_context(message, cls=cls)
         
 
-bot = MyBot(command_prefix='!')
+bot = MyBot(command_prefix='!', intents=discord.Intents(guilds=True, messages=True))
 
 @bot.command()
 async def guess(ctx, number: int):

--- a/examples/deleted.py
+++ b/examples/deleted.py
@@ -17,5 +17,5 @@ class MyClient(discord.Client):
         msg = f'{message.author} has deleted the message: {message.content}'
         await message.channel.send(msg)
 
-client = MyClient()
+client = MyClient(intents=discord.Intents(guilds=True, messages=True))
 client.run('token')

--- a/examples/edits.py
+++ b/examples/edits.py
@@ -16,5 +16,5 @@ class MyClient(discord.Client):
         msg = f'**{before.author}** edited their message:\n{before.content} -> {after.content}'
         await before.channel.send(msg)
 
-client = MyClient()
+client = MyClient(intents=discord.Intents(guilds=True, messages=True))
 client.run('token')

--- a/examples/guessing_game.py
+++ b/examples/guessing_game.py
@@ -30,5 +30,5 @@ class MyClient(discord.Client):
             else:
                 await message.channel.send(f'Oops. It is actually {answer}.')
 
-client = MyClient()
+client = MyClient(intents=discord.Intents(guilds=True, messages=True))
 client.run('token')

--- a/examples/new_member.py
+++ b/examples/new_member.py
@@ -14,8 +14,5 @@ class MyClient(discord.Client):
             await guild.system_channel.send(to_send)
 
 
-intents = discord.Intents.default()
-intents.members = True
-
-client = MyClient(intents=intents)
+client = MyClient(intents=discord.Intents(guilds=True, members=True))
 client.run('token')

--- a/examples/reaction_roles.py
+++ b/examples/reaction_roles.py
@@ -78,8 +78,6 @@ class MyClient(discord.Client):
             # If we want to do something in case of errors we'd do it here.
             pass
 
-intents = discord.Intents.default()
-intents.members = True
-
+intents = discord.Intents(guilds=True, members=True, guild_reactions=True)
 client = MyClient(intents=intents)
 client.run('token')

--- a/examples/reply.py
+++ b/examples/reply.py
@@ -13,5 +13,5 @@ class MyClient(discord.Client):
         if message.content.startswith('!hello'):
             await message.reply('Hello!', mention_author=True)
 
-client = MyClient()
+client = MyClient(intents=discord.Intents(guilds=True, messages=True))
 client.run('token')

--- a/examples/secret.py
+++ b/examples/secret.py
@@ -3,7 +3,11 @@ import typing
 import discord
 from discord.ext import commands
 
-bot = commands.Bot(command_prefix=commands.when_mentioned, description="Nothing to see here!")
+bot = commands.Bot(
+    command_prefix=commands.when_mentioned,
+    description="Nothing to see here!",
+    intents=discord.Intents(guilds=True, messages=True)
+)
 
 # the `hidden` keyword argument hides it from the help command. 
 @bot.group(hidden=True)

--- a/examples/views/confirm.py
+++ b/examples/views/confirm.py
@@ -5,7 +5,10 @@ import discord
 
 class Bot(commands.Bot):
     def __init__(self):
-        super().__init__(command_prefix=commands.when_mentioned_or('$'))
+        super().__init__(
+            command_prefix=commands.when_mentioned_or('$'),
+            intents=discord.Intents(guilds=True, messages=True)
+        )
 
     async def on_ready(self):
         print(f'Logged in as {self.user} (ID: {self.user.id})')

--- a/examples/views/counter.py
+++ b/examples/views/counter.py
@@ -5,7 +5,10 @@ import discord
 
 class CounterBot(commands.Bot):
     def __init__(self):
-        super().__init__(command_prefix=commands.when_mentioned_or('$'))
+        super().__init__(
+            command_prefix=commands.when_mentioned_or('$'),
+            intents=discord.Intents(guilds=True, messages=True)
+        )
 
     async def on_ready(self):
         print(f'Logged in as {self.user} (ID: {self.user.id})')

--- a/examples/views/dropdown.py
+++ b/examples/views/dropdown.py
@@ -1,5 +1,3 @@
-import typing
-
 import discord
 from discord.ext import commands
 
@@ -39,7 +37,10 @@ class DropdownView(discord.ui.View):
 
 class Bot(commands.Bot):
     def __init__(self):
-        super().__init__(command_prefix=commands.when_mentioned_or('$'))
+        super().__init__(
+            command_prefix=commands.when_mentioned_or('$'),
+            intents=discord.Intents(guilds=True, messages=True)
+        )
 
     async def on_ready(self):
         print(f'Logged in as {self.user} (ID: {self.user.id})')

--- a/examples/views/ephemeral.py
+++ b/examples/views/ephemeral.py
@@ -4,7 +4,10 @@ import discord
 
 class EphemeralCounterBot(commands.Bot):
     def __init__(self):
-        super().__init__(command_prefix=commands.when_mentioned_or('$'))
+        super().__init__(
+            command_prefix=commands.when_mentioned_or('$'),
+            intents=discord.Intents(guilds=True, messages=True)
+        )
 
     async def on_ready(self):
         print(f'Logged in as {self.user} (ID: {self.user.id})')

--- a/examples/views/link.py
+++ b/examples/views/link.py
@@ -5,7 +5,10 @@ from urllib.parse import quote_plus
 
 class GoogleBot(commands.Bot):
     def __init__(self):
-        super().__init__(command_prefix=commands.when_mentioned_or('$'))
+        super().__init__(
+            command_prefix=commands.when_mentioned_or('$'),
+            intents=discord.Intents(guilds=True, messages=True)
+        )
 
     async def on_ready(self):
         print(f'Logged in as {self.user} (ID: {self.user.id})')
@@ -36,4 +39,4 @@ async def google(ctx: commands.Context, *, query: str):
     await ctx.send(f'Google Result for: `{query}`', view=Google(query))
 
 
-bot.run('token')
+bot.run()

--- a/examples/views/persistent.py
+++ b/examples/views/persistent.py
@@ -29,7 +29,11 @@ class PersistentView(discord.ui.View):
 
 class PersistentViewBot(commands.Bot):
     def __init__(self):
-        super().__init__(command_prefix=commands.when_mentioned_or('$'))
+        super().__init__(
+            command_prefix=commands.when_mentioned_or('$'),
+            intents=discord.Intents(guilds=True, messages=True)
+        )
+
         self.persistent_views_added = False
 
     async def on_ready(self):

--- a/examples/views/tic_tac_toe.py
+++ b/examples/views/tic_tac_toe.py
@@ -120,7 +120,10 @@ class TicTacToe(discord.ui.View):
 
 class TicTacToeBot(commands.Bot):
     def __init__(self):
-        super().__init__(command_prefix=commands.when_mentioned_or('$'))
+        super().__init__(
+            command_prefix=commands.when_mentioned_or('$'),
+            intents=discord.Intents(guilds=True, messages=True)
+        )
 
     async def on_ready(self):
         print(f'Logged in as {self.user} (ID: {self.user.id})')


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
This PR removes the concept of default intents, as of Discord API v8 it is required. This should make any developers unaware of intents have to learn them, allowing further optimized code and less confusion as to (for example) `discord.Guild.members` being empty for a first time user. I have updated all the examples in the examples folder of the repo, although there may be some more in the docs unchanged.
## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
