### PR TITLE
Fix `TypeError` when setting `Embed.thumbnail` and `Embed.image` property

### DIFF
--- a/discord/embeds.py
+++ b/discord/embeds.py
@@ -404,7 +404,7 @@ class Embed:
         return EmbedProxy(getattr(self, '_image', {}))  # type: ignore
 
     @image.setter
-    def image(self: E, *, url: Any):
+    def image(self: E, url: Any):
         self._image = {
             'url': str(url),
         }
@@ -454,7 +454,7 @@ class Embed:
         return EmbedProxy(getattr(self, '_thumbnail', {}))  # type: ignore
 
     @thumbnail.setter
-    def thumbnail(self: E, *, url: Any):
+    def thumbnail(self: E, url: Any):
         """Sets the thumbnail for the embed content.
         """
 

--- a/discord/embeds.py
+++ b/discord/embeds.py
@@ -455,17 +455,12 @@ class Embed:
 
     @thumbnail.setter
     def thumbnail(self: E, url: Any):
-        """Sets the thumbnail for the embed content.
-        """
-
         if url is EmptyEmbed:
             del self._thumbnail
         else:
             self._thumbnail = {
                 'url': str(url),
             }
-
-        return
 
     @thumbnail.deleter
     def thumbnail(self):

--- a/discord/embeds.py
+++ b/discord/embeds.py
@@ -405,9 +405,12 @@ class Embed:
 
     @image.setter
     def image(self: E, url: Any):
-        self._image = {
-            'url': str(url),
-        }
+        if url is EmptyEmbed:
+            del self._image
+        else:
+            self._image = {
+                'url': str(url),
+            }
 
     @image.deleter
     def image(self: E):
@@ -431,10 +434,7 @@ class Embed:
             The source URL for the image. Only HTTP(S) is supported.
         """
 
-        if url is EmptyEmbed:
-            del self.image
-        else:
-            self.image = url
+        self.image = url
 
         return self
 
@@ -458,9 +458,12 @@ class Embed:
         """Sets the thumbnail for the embed content.
         """
 
-        self._thumbnail = {
-            'url': str(url),
-        }
+        if url is EmptyEmbed:
+            del self._thumbnail
+        else:
+            self._thumbnail = {
+                'url': str(url),
+            }
 
         return
 
@@ -485,10 +488,8 @@ class Embed:
         url: :class:`str`
             The source URL for the thumbnail. Only HTTP(S) is supported.
         """
-        if url is EmptyEmbed:
-            del self.thumbnail
-        else:
-            self.thumbnail = url
+
+        self.thumbnail = url
 
         return self
 


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Fixed `TypeError: image() takes 1 positional argument but 2 were given`

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
