### PR TITLE
FIx `_accent_colour` being improperly typehinted

### DIFF
--- a/discord/user.py
+++ b/discord/user.py
@@ -80,7 +80,7 @@ class BaseUser(_UserTag):
         _state: ConnectionState
         _avatar: Optional[str]
         _banner: Optional[str]
-        _accent_colour: Optional[str]
+        _accent_colour: Optional[int]
         _public_flags: int
 
     def __init__(self, *, state: ConnectionState, data: UserPayload) -> None:


### PR DESCRIPTION
## Summary

`_accent_colour` in `discord.User` was typehinted as a `Optional[str]` when it's stated to be an `Optional[int]` (or, well `?integer`) by the [Discord API docs](https://discord.com/developers/docs/resources/user#user-object-user-structure) and is treated by the library as an `Optional[int]` when `User.accent_colour` is called. This PR is a quick change to fix that (and make Pylance happy).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
