### PR TITLE
Adds the new `ephemeral` field on `discord.Attachment`

### DIFF
--- a/discord/message.py
+++ b/discord/message.py
@@ -169,9 +169,14 @@ class Attachment(Hashable):
         The attachment's `media type <https://en.wikipedia.org/wiki/Media_type>`_
 
         .. versionadded:: 1.7
+    ephemeral: Optional[:class:`bool`]
+        If the attachment is ephemeral. Ephemeral attachments are temporary and
+        will automatically be removed after a set period of time.
+
+        .. versionadded:: 2.0
     """
 
-    __slots__ = ("id", "size", "height", "width", "filename", "url", "proxy_url", "_http", "content_type")
+    __slots__ = ("id", "size", "height", "width", "filename", "url", "proxy_url", "ephemeral" "_http", "content_type")
 
     def __init__(self, *, data: AttachmentPayload, state: ConnectionState):
         self.id: int = int(data["id"])
@@ -183,6 +188,7 @@ class Attachment(Hashable):
         self.proxy_url: str = data.get("proxy_url")
         self._http = state.http
         self.content_type: Optional[str] = data.get("content_type")
+        self.ephemeral: Optional[bool] = data.get("ephemeral")
 
     def is_spoiler(self) -> bool:
         """:class:`bool`: Whether this attachment contains a spoiler."""

--- a/discord/message.py
+++ b/discord/message.py
@@ -176,7 +176,7 @@ class Attachment(Hashable):
         .. versionadded:: 2.0
     """
 
-    __slots__ = ("id", "size", "height", "width", "filename", "url", "proxy_url", "ephemeral" "_http", "content_type")
+    __slots__ = ("id", "size", "height", "width", "filename", "url", "proxy_url", "ephemeral", "_http", "content_type")
 
     def __init__(self, *, data: AttachmentPayload, state: ConnectionState):
         self.id: int = int(data["id"])

--- a/discord/types/message.py
+++ b/discord/types/message.py
@@ -53,6 +53,7 @@ class _AttachmentOptional(TypedDict, total=False):
     height: Optional[int]
     width: Optional[int]
     content_type: str
+    ephemeral: bool
     spoiler: bool
 
 


### PR DESCRIPTION
<!-- Pull requests that do not fill this information in will likely be closed -->

## Summary
Implements the `ephemeral` field on attachment objects, see https://github.com/discord/discord-api-docs/commit/d61166446ec954d2b8f561db0d87701df5de69d9 for more info. It seems like these can currently only be sent via the followup webhook of an interaction.

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)