### PR TITLE
Add better support for mentionable

### DIFF
--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -54,7 +54,16 @@ import discord
 
 from .errors import *
 from .cooldowns import Cooldown, BucketType, CooldownMapping, MaxConcurrency, DynamicCooldownMapping
-from .converter import CONVERTER_MAPPING, Converter, run_converters, get_converter, Greedy, Option
+from .converter import (
+    CONVERTER_MAPPING,
+    Converter,
+    MemberConverter,
+    RoleConverter,
+    run_converters,
+    get_converter,
+    Greedy,
+    Option,
+)
 from ._types import _BaseCommand
 from .cog import Cog
 from .context import Context
@@ -125,7 +134,6 @@ application_option_type_lookup = {
     ): 6,  # Preferably discord.abc.User, but 'Protocols with non-method members don't support issubclass()'
     (discord.abc.GuildChannel, discord.DMChannel): 7,
     discord.Role: 8,
-    discord.Object: 9,
     float: 10,
 }
 
@@ -1208,7 +1216,6 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
     def _param_to_options(
         self, name: str, annotation: Any, required: bool, varadic: bool
     ) -> List[Optional[ApplicationCommandInteractionDataOption]]:
-
         origin = getattr(annotation, "__origin__", None)
         if inspect.isclass(annotation) and issubclass(annotation, FlagConverter):
             return [
@@ -1228,6 +1235,7 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
             annotation, origin = annotation.__args__[0], None
 
         option: Dict[str, Any] = {
+            "type": 3,
             "name": name,
             "required": required,
             "description": self.option_descriptions[name],
@@ -1242,11 +1250,14 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
                 # one, in which we can get the original type, eg, (MemberConverter -> Member)
                 annotation = REVERSED_CONVERTER_MAPPING.get(annotation, annotation)
 
-            option["type"] = 3
             for python_type, discord_type in application_option_type_lookup.items():
                 if issubclass(annotation, python_type):
                     option["type"] = discord_type
                     break
+
+        elif origin is Union:
+            if annotation in {Union[discord.Member, discord.Role], Union[MemberConverter, RoleConverter]}:
+                option["type"] = 9
 
         elif origin is Literal:
             literal_values = annotation.__args__
@@ -1261,7 +1272,6 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
                     {"name": literal_value, "value": literal_value} for literal_value in annotation.__args__
                 ]
 
-        option.setdefault("type", 3)  # STRING
         return [option]  # type: ignore
 
     def to_application_command(self, nested: int = 0) -> Optional[EditApplicationCommand]:


### PR DESCRIPTION
<!-- Pull requests that do not fill this information in will likely be closed -->

## Summary
<!-- What is this pull request for? Does it fix any issues? -->
Previously, slash command's simply converted `discord.Object` into mentionable (type 9) but that wasn't entirely correct, as discord treats mentionable as `Union[discord.Member, discord.Role]`, so, I did a small change to correct this. 

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
