### PR TITLE
add support for delete_after kwarg for interaction and webhook messages

### DIFF
--- a/discord/ext/commands/context.py
+++ b/discord/ext/commands/context.py
@@ -465,7 +465,6 @@ class Context(discord.abc.Messageable, Generic[BotT]):
         kwargs.pop("nonce", None)
         kwargs.pop("stickers", None)
         kwargs.pop("reference", None)
-        kwargs.pop("delete_after", None)
         kwargs.pop("mention_author", None)
 
         if not (

--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -749,7 +749,7 @@ class InteractionMessage(Message):
             allowed_mentions=allowed_mentions,
         )
 
-    async def delete(self, *, delay: Optional[float] = None) -> None:
+    async def delete(self, *, delay: Optional[float] = None, silent: bool = False) -> None:
         """|coro|
 
         Deletes the message.
@@ -759,6 +759,12 @@ class InteractionMessage(Message):
         delay: Optional[:class:`float`]
             If provided, the number of seconds to wait before deleting the message.
             The waiting is done in the background and deletion failures are ignored.
+        
+        silent: :class:`bool`
+            If silent is set to ``True``, the error will not be raised, it will be ignored.
+            This defaults to ``False`
+        
+        .. versionadded:: 2.0
 
         Raises
         ------
@@ -780,4 +786,8 @@ class InteractionMessage(Message):
 
             asyncio.create_task(inner_call())
         else:
-            await self._state._interaction.delete_original_message(delay=delay)
+            try:
+                await self._state._interaction.delete_original_message(delay=delay)
+            except Exception:
+                if not silent:
+                    raise

--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -350,6 +350,8 @@ class Interaction:
         delay: Optional[:class:`float`]
             If provided, the number of seconds to wait before deleting the message.
             The waiting is done in the background and deletion failures are ignored.
+            
+            .. versionadded:: 2.0
 
         Raises
         -------
@@ -494,6 +496,7 @@ class InteractionResponse:
             is set to 15 minutes.
         delete_after: Optional[:class:`float`]
             The amount of seconds the bot should wait before deleting the message sent.
+            .. versionadded:: 2.0
 
         Raises
         -------

--- a/discord/webhook/async_.py
+++ b/discord/webhook/async_.py
@@ -717,7 +717,7 @@ class WebhookMessage(Message):
             allowed_mentions=allowed_mentions,
         )
 
-    async def delete(self, *, delay: Optional[float] = None) -> None:
+    async def delete(self, *, delay: Optional[float] = None, silent: bool = False) -> None:
         """|coro|
 
         Deletes the message.
@@ -727,6 +727,12 @@ class WebhookMessage(Message):
         delay: Optional[:class:`float`]
             If provided, the number of seconds to wait before deleting the message.
             The waiting is done in the background and deletion failures are ignored.
+        
+        silent: :class:`bool`
+            If silent is set to ``True``, the error will not be raised, it will be ignored.
+            This defaults to ``False`
+        
+        .. versionadded:: 2.0
 
         Raises
         ------
@@ -748,7 +754,11 @@ class WebhookMessage(Message):
 
             asyncio.create_task(inner_call())
         else:
-            await self._state._webhook.delete_message(self.id, delay)
+            try:
+                await self._state._webhook.delete_message(self.id, delay)
+            except Exception:
+                if not silent:
+                    raise
 
 
 class BaseWebhook(Hashable):

--- a/discord/webhook/async_.py
+++ b/discord/webhook/async_.py
@@ -742,13 +742,13 @@ class WebhookMessage(Message):
 
             async def inner_call(delay: float = delay):
                 try:
-                    await self._state._webhook.delete_message(self.id, delay=delay)
+                    await self._state._webhook.delete_message(self.id, delay)
                 except HTTPException:
                     pass
 
             asyncio.create_task(inner_call())
         else:
-            await self._state._webhook.delete_message(self.id, delay=delay)
+            await self._state._webhook.delete_message(self.id, delay)
 
 
 class BaseWebhook(Hashable):

--- a/discord/webhook/async_.py
+++ b/discord/webhook/async_.py
@@ -1339,6 +1339,7 @@ class Webhook(BaseWebhook):
         delete_after: Optional[:class:`float`]
             If provided, the number of seconds to wait before deleting the message.
             The waiting is done in the background and deletion failures are ignored.
+            .. versionadded:: 2.0
 
         Raises
         --------
@@ -1595,6 +1596,8 @@ class Webhook(BaseWebhook):
         delay: Optional[:class:`float`]
             If provided, the number of seconds to wait before deleting the message.
             The waiting is done in the background and deletion failures are ignored.
+            
+            .. versionadded:: 2.0
 
         Raises
         -------


### PR DESCRIPTION
<!-- Pull requests that do not fill this information in will likely be closed -->

## Summary
adds a `delete_message: Optional[float] = None` kwarg to `interaction.send_message` and `Webhook.send`.
adds a `delay: Optional[float] = None` parameter to `Interaction.delete_original_message`.

note: `delete_after` for `Webhook.send` will only work if `wait` kwarg is `True`.

## Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
