### PR TITLE
Make `fetch_x` methods cache when applicable

### DIFF
--- a/discord/abc.py
+++ b/discord/abc.py
@@ -1434,7 +1434,7 @@ class Messageable:
                 components=components,
             )
 
-        ret = state.create_message(channel=channel, data=data)
+        ret = state.store_message(channel=channel, data=data)
         if view:
             state.store_view(view, ret.id)
 
@@ -1501,7 +1501,7 @@ class Messageable:
 
         channel = await self._get_channel()
         data = await self._state.http.get_message(channel.id, id)
-        return self._state.create_message(channel=channel, data=data)
+        return self._state.store_message(channel=channel, data=data)
 
     async def pins(self) -> List[Message]:
         """|coro|
@@ -1528,7 +1528,7 @@ class Messageable:
         channel = await self._get_channel()
         state = self._state
         data = await state.http.pins_from(channel.id)
-        return [state.create_message(channel=channel, data=m) for m in data]
+        return [state.store_message(channel=channel, data=m) for m in data]
 
     def history(
         self,

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -1694,7 +1694,9 @@ class Group(GroupMixin[CogT], Command[CogT, P, T]):
             "name": self.name,
             "type": int(not (nested - 1)) + 1,
             "description": self.short_doc or "no description",
-            "options": [cmd.to_application_command(nested=nested + 1) for cmd in sorted(self.commands, key=lambda x: x.name)],
+            "options": [
+                cmd.to_application_command(nested=nested + 1) for cmd in sorted(self.commands, key=lambda x: x.name)
+            ],
         }
 
 

--- a/discord/ext/commands/errors.py
+++ b/discord/ext/commands/errors.py
@@ -455,7 +455,7 @@ class BadInviteArgument(BadArgument):
     This inherits from :exc:`BadArgument`
 
     .. versionadded:: 1.5
-    
+
     Attributes
     -----------
     argument: :class:`str`

--- a/discord/flags.py
+++ b/discord/flags.py
@@ -951,6 +951,15 @@ class MemberCacheFlags(BaseFlags):
         """
         return 2
 
+    @flag_value
+    def fetched(self):
+        """:class:`bool`: Whether to cache members that are fetched via :meth:``Guild.fetch_member``
+        or :meth:``Guild.fetch_members``
+
+        Members that leave the guild are no longer cached.
+        """
+        return 4
+
     @classmethod
     def from_intents(cls: Type[MemberCacheFlags], intents: Intents) -> MemberCacheFlags:
         """A factory method that creates a :class:`MemberCacheFlags` based on
@@ -968,6 +977,8 @@ class MemberCacheFlags(BaseFlags):
         """
 
         self = cls.none()
+        self.fetched = True
+
         if intents.members:
             self.joined = True
         if intents.voice_states:

--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -137,7 +137,7 @@ class Interaction:
 
         self.message: Optional[Message]
         try:
-            self.message = Message(state=self._state, channel=self.channel, data=data["message"])  # type: ignore
+            self.message = self._state.store_message(channel=self.channel, data=data["message"])  # type: ignore
         except KeyError:
             self.message = None
 

--- a/discord/message.py
+++ b/discord/message.py
@@ -1331,7 +1331,7 @@ class Message(Hashable):
                 payload["components"] = []
 
         data = await self._state.http.edit_message(self.channel.id, self.id, **payload)
-        message = Message(state=self._state, channel=self.channel, data=data)
+        message = self._state.store_message(channel=self.channel, data=data)
 
         if view and not view.is_finished():
             self._state.store_view(view, self.id)
@@ -1756,7 +1756,7 @@ class PartialMessage(Hashable):
         """
 
         data = await self._state.http.get_message(self.channel.id, self.id)
-        return self._state.create_message(channel=self.channel, data=data)
+        return self._state.store_message(channel=self.channel, data=data)
 
     async def edit(self, **fields: Any) -> Optional[Message]:
         """|coro|
@@ -1873,7 +1873,7 @@ class PartialMessage(Hashable):
 
         if fields:
             # data isn't unbound
-            msg = self._state.create_message(channel=self.channel, data=data)  # type: ignore
+            msg = self._state.store_message(channel=self.channel, data=data)  # type: ignore
             if view and not view.is_finished():
                 self._state.store_view(view, self.id)
             return msg


### PR DESCRIPTION
<!-- Pull requests that do not fill this information in will likely be closed -->

## Summary
<!-- What is this pull request for? Does it fix any issues? -->
For methods that can/make sense to, will add to cache so `get_x` works (and `try_x` uses less api calls), also adds a new flag (`fetched`) to `MemberCacheFlags` in order to be able to disable this behavior for `fetch_member` and `fetch_members`
## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
