### PR TITLE
Implement `delete_after` kwarg for webhook and interaction responses

### DIFF
--- a/discord/ext/commands/context.py
+++ b/discord/ext/commands/context.py
@@ -471,7 +471,6 @@ class Context(discord.abc.Messageable, Generic[BotT]):
         kwargs.pop("nonce", None)
         kwargs.pop("stickers", None)
         kwargs.pop("reference", None)
-        kwargs.pop("delete_after", None)
         kwargs.pop("mention_author", None)
 
         if not (

--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -462,6 +462,7 @@ class InteractionResponse:
         view: View = MISSING,
         tts: bool = False,
         ephemeral: bool = False,
+        delete_after: float = MISSING,
     ) -> None:
         """|coro|
 
@@ -541,6 +542,16 @@ class InteractionResponse:
             self._parent._state.store_view(view)
 
         self.responded_at = utils.utcnow()
+
+        if delete_after is not MISSING:
+            async def delete(delay: float):
+                await asyncio.sleep(delay)
+                try:
+                    await parent.delete_original_message()
+                except HTTPException:
+                    pass
+
+            asyncio.create_task(delete(delete_after))
 
     async def edit_message(
         self,

--- a/discord/webhook/async_.py
+++ b/discord/webhook/async_.py
@@ -1231,6 +1231,7 @@ class Webhook(BaseWebhook):
         view: View = MISSING,
         thread: Snowflake = MISSING,
         wait: Literal[True],
+        delete_after: float = MISSING,
     ) -> WebhookMessage:
         ...
 
@@ -1251,6 +1252,7 @@ class Webhook(BaseWebhook):
         view: View = MISSING,
         thread: Snowflake = MISSING,
         wait: Literal[False] = ...,
+        delete_after: float = MISSING,
     ) -> None:
         ...
 
@@ -1270,6 +1272,7 @@ class Webhook(BaseWebhook):
         view: View = MISSING,
         thread: Snowflake = MISSING,
         wait: bool = False,
+        delete_after: float = MISSING,
     ) -> Optional[WebhookMessage]:
         """|coro|
 
@@ -1335,6 +1338,10 @@ class Webhook(BaseWebhook):
             The thread to send this webhook to.
 
             .. versionadded:: 2.0
+        delete_after: :class:`float`
+            If provided, the number of seconds to wait in the background
+            before deleting the message we just sent. If the deletion fails,
+            then it is silently ignored.
 
         Raises
         --------
@@ -1398,6 +1405,9 @@ class Webhook(BaseWebhook):
         if thread is not MISSING:
             thread_id = thread.id
 
+        if delete_after is not MISSING:
+            wait = True
+
         data = await adapter.execute_webhook(
             self.id,
             self.token,
@@ -1417,6 +1427,9 @@ class Webhook(BaseWebhook):
             message_id = None if msg is None else msg.id
             self._state.store_view(view, message_id)
 
+        if delete_after is not MISSING:
+            await msg.delete(delay=delete_after)
+    
         return msg
 
     async def fetch_message(self, id: int) -> WebhookMessage:

--- a/discord/webhook/sync.py
+++ b/discord/webhook/sync.py
@@ -790,6 +790,7 @@ class SyncWebhook(BaseWebhook):
         embeds: List[Embed] = MISSING,
         allowed_mentions: AllowedMentions = MISSING,
         wait: Literal[True],
+        delete_after: float = MISSING,
     ) -> SyncWebhookMessage:
         ...
 
@@ -807,6 +808,7 @@ class SyncWebhook(BaseWebhook):
         embeds: List[Embed] = MISSING,
         allowed_mentions: AllowedMentions = MISSING,
         wait: Literal[False] = ...,
+        delete_after: float = MISSING,
     ) -> None:
         ...
 
@@ -824,6 +826,7 @@ class SyncWebhook(BaseWebhook):
         allowed_mentions: AllowedMentions = MISSING,
         thread: Snowflake = MISSING,
         wait: bool = False,
+        delete_after: float = MISSING,
     ) -> Optional[SyncWebhookMessage]:
         """Sends a message using the webhook.
 
@@ -872,6 +875,10 @@ class SyncWebhook(BaseWebhook):
             The thread to send this message to.
 
             .. versionadded:: 2.0
+        delete_after: :class:`float`
+            If provided, the number of seconds to wait in the background
+            before deleting the message we just sent. If the deletion fails,
+            then it is silently ignored.
 
         Raises
         --------
@@ -918,6 +925,9 @@ class SyncWebhook(BaseWebhook):
         if thread is not MISSING:
             thread_id = thread.id
 
+        if delete_after is not MISSING:
+            wait = True
+
         data = adapter.execute_webhook(
             self.id,
             self.token,
@@ -928,8 +938,13 @@ class SyncWebhook(BaseWebhook):
             thread_id=thread_id,
             wait=wait,
         )
-        if wait:
-            return self._create_message(data)
+
+        msg = self._create_message(data) if wait else None
+        
+        if delete_after is not MISSING:
+            msg.delete(delay=delete_after)
+        
+        return msg
 
     def fetch_message(self, id: int, /) -> SyncWebhookMessage:
         """Retrieves a single :class:`~discord.SyncWebhookMessage` owned by this webhook.


### PR DESCRIPTION
<!-- Pull requests that do not fill this information in will likely be closed -->

## Summary

Implements the `delete_after` kwarg for webhooks and interaction responses.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
