### PR TITLE
Add support for editing in files and set file descriptions

### DIFF
--- a/discord/abc.py
+++ b/discord/abc.py
@@ -1335,11 +1335,12 @@ class Messageable:
             raise InvalidArgument("cannot pass both embed and embeds parameter to send()")
 
         if embed is not None:
-            embed = embed.to_dict()
+            embeds = [embed]
 
-        elif embeds is not None:
+        if embeds is not None:
             if len(embeds) > 10:
                 raise InvalidArgument("embeds parameter must be a list of up to 10 elements")
+
             embeds = [embed.to_dict() for embed in embeds]
 
         if stickers is not None:
@@ -1380,24 +1381,9 @@ class Messageable:
             if not isinstance(file, File):
                 raise InvalidArgument("file parameter must be File")
 
-            try:
-                data = await state.http.send_files(
-                    channel.id,
-                    files=[file],
-                    allowed_mentions=allowed_mentions,
-                    content=content,
-                    tts=tts,
-                    embed=embed,
-                    embeds=embeds,
-                    nonce=nonce,
-                    message_reference=reference,
-                    stickers=stickers,
-                    components=components,
-                )
-            finally:
-                file.close()
+            files = [file]
 
-        elif files is not None:
+        if files is not None:
             if len(files) > 10:
                 raise InvalidArgument("files parameter must be a list of up to 10 elements")
             elif not all(isinstance(file, File) for file in files):
@@ -1409,7 +1395,6 @@ class Messageable:
                     files=files,
                     content=content,
                     tts=tts,
-                    embed=embed,
                     embeds=embeds,
                     nonce=nonce,
                     allowed_mentions=allowed_mentions,
@@ -1440,6 +1425,7 @@ class Messageable:
 
         if delete_after is not None:
             await ret.delete(delay=delete_after)
+
         return ret
 
     async def trigger_typing(self) -> None:

--- a/discord/file.py
+++ b/discord/file.py
@@ -60,14 +60,19 @@ class File:
         a string then the ``filename`` will default to the string given.
     spoiler: :class:`bool`
         Whether the attachment is a spoiler.
+    description: Optional[:class:`str`]
+        The description (alt text) for the file.
+
+        .. versionadded:: 2.0
     """
 
-    __slots__ = ("fp", "filename", "spoiler", "_original_pos", "_owner", "_closer")
+    __slots__ = ("fp", "filename", "spoiler", "description", "_original_pos", "_owner", "_closer")
 
     if TYPE_CHECKING:
         fp: io.BufferedIOBase
         filename: Optional[str]
         spoiler: bool
+        description: Optional[str]
 
     def __init__(
         self,
@@ -75,6 +80,7 @@ class File:
         filename: Optional[str] = None,
         *,
         spoiler: bool = False,
+        description: Optional[str] = None,
     ):
         if isinstance(fp, io.IOBase):
             if not (fp.seekable() and fp.readable()):
@@ -106,6 +112,7 @@ class File:
             self.filename = "SPOILER_" + self.filename
 
         self.spoiler = spoiler or (self.filename is not None and self.filename.startswith("SPOILER_"))
+        self.description = description
 
     def reset(self, *, seek: Union[int, bool] = True) -> None:
         # The `seek` parameter is needed because

--- a/discord/http.py
+++ b/discord/http.py
@@ -474,6 +474,7 @@ class HTTPClient:
     def multipart_request_helper(
         self,
         route: Route,
+        *,
         files: Sequence[File],
         allowed_mentions: Optional[message.AllowedMentions] = None,
         attachments: Optional[List[message.Attachment]] = None,
@@ -525,7 +526,7 @@ class HTTPClient:
 
     def send_files(self, channel_id: Snowflake, *, files: Sequence[File], **fields: Any) -> Response[message.Message]:
         r = Route("POST", "/channels/{channel_id}/messages", channel_id=channel_id)
-        return self.multipart_request_helper(r, files, **fields)
+        return self.multipart_request_helper(r, files=files, **fields)
 
     def edit_files(
         self,
@@ -537,7 +538,7 @@ class HTTPClient:
     ) -> Response[message.Message]:
         fields["tts"] = None
         r = Route("PATCH", "/channels/{channel_id}/messages/{message_id}", channel_id=channel_id, message_id=message_id)
-        return self.multipart_request_helper(r, files, **fields)
+        return self.multipart_request_helper(r, files=files, **fields)
 
     def delete_message(
         self, channel_id: Snowflake, message_id: Snowflake, *, reason: Optional[str] = None

--- a/discord/message.py
+++ b/discord/message.py
@@ -1258,10 +1258,14 @@ class Message(Hashable):
         attachments: List[:class:`Attachment`]
             A list of attachments to keep in the message. If ``[]`` is passed
             then all attachments are removed.
-        file: Optional[:class:`File`]
-            ...
-        files: List[:class:`File`]
-            ...
+        file: :class:`~discord.File`
+            The file to upload.
+
+            .. versionadded:: 2.0
+        files: List[:class:`~discord.File`]
+            A list of files to upload. Must be a maximum of 10.
+
+            .. versionadded:: 2.0
         suppress: :class:`bool`
             Whether to suppress embeds for the message. This removes
             all the embeds if set to ``True``. If set to ``False``

--- a/discord/types/message.py
+++ b/discord/types/message.py
@@ -55,6 +55,7 @@ class _AttachmentOptional(TypedDict, total=False):
     content_type: str
     ephemeral: bool
     spoiler: bool
+    description: Optional[str]
 
 
 class Attachment(_AttachmentOptional):


### PR DESCRIPTION
<!-- Pull requests that do not fill this information in will likely be closed -->

## Summary

This PR adds a file and files kwargs to `Message.edit()` to support adding attachments to the message. This is also formats other parts like sending embeds and files for `Messageable.send()`.

This PR also adds support for setting a description on files (or attachments). Fixes #119 

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
