### PR TITLE
Add support for guild specific banner

### DIFF
--- a/discord/asset.py
+++ b/discord/asset.py
@@ -246,6 +246,17 @@ class Asset(AssetMixin):
         )
 
     @classmethod
+    def _from_member_banner(cls, state, guild_id: int, member_id: int, banner_hash: str) -> Asset:
+        animated = banner_hash.startswith("a_")
+        format = "gif" if animated else "png"
+        return cls(
+            state,
+            url=f"{cls.BASE}/guilds/{guild_id}/users/{member_id}/banners/{banner_hash}.{format}?size=512",
+            key=banner_hash,
+            animated=animated,
+        )
+
+    @classmethod
     def _from_role_icon(cls, state, role_id: int, role_hash: str) -> Asset:
         return cls(
             state,

--- a/discord/member.py
+++ b/discord/member.py
@@ -271,6 +271,8 @@ class Member(discord.abc.Messageable, _UserTag):
         "_user",
         "_state",
         "_avatar",
+        "_guild_banner",
+        "user_banner",
     )
 
     if TYPE_CHECKING:
@@ -286,7 +288,6 @@ class Member(discord.abc.Messageable, _UserTag):
         create_dm = User.create_dm
         mutual_guilds: List[Guild]
         public_flags: PublicUserFlags
-        banner: Optional[Asset]
         accent_color: Optional[Colour]
         accent_colour: Optional[Colour]
 
@@ -302,6 +303,8 @@ class Member(discord.abc.Messageable, _UserTag):
         self.nick: Optional[str] = data.get("nick", None)
         self.pending: bool = data.get("pending", False)
         self._avatar: Optional[str] = data.get("avatar")
+        self._guild_banner: Optional[str] = data.get("banner")
+        self.user_banner: Optional[Asset] = self._user.banner
 
     def __str__(self) -> str:
         return str(self._user)
@@ -536,6 +539,37 @@ class Member(discord.abc.Messageable, _UserTag):
         if self._avatar is None:
             return None
         return Asset._from_guild_avatar(self._state, self.guild.id, self.id, self._avatar)
+
+    @property
+    def display_banner(self) -> Optional[Asset]:
+        """:class:`Asset`: Returns the member's display banner.
+
+        For regular members this is just their banner, but
+        if they have a guild specific banner then that
+        is returned instead.
+
+        .. versionadded:: 2.0
+
+
+        .. note::
+            This information is only available via :meth:`Client.fetch_user`.
+        """
+        return self.guild_banner or self.user_banner
+
+    @property
+    def guild_banner(self) -> Optional[Asset]:
+        """Optional[:class:`Asset`]: Returns an :class:`Asset` for the guild banner
+        the member has. If unavailable, ``None`` is returned.
+
+        .. versionadded:: 2.0
+
+
+        .. note::
+            This information is only available via :meth:`Client.fetch_user`.
+        """
+        if self._guild_banner is None:
+            return None
+        return Asset._from_member_banner(self._state, self.guild.id, self.id, self._guild_banner)
 
     @property
     def activity(self) -> Optional[ActivityTypes]:

--- a/discord/member.py
+++ b/discord/member.py
@@ -272,7 +272,6 @@ class Member(discord.abc.Messageable, _UserTag):
         "_state",
         "_avatar",
         "_guild_banner",
-        "user_banner",
     )
 
     if TYPE_CHECKING:
@@ -280,6 +279,7 @@ class Member(discord.abc.Messageable, _UserTag):
         id: int
         discriminator: str
         bot: bool
+        banner: Optional[Asset]
         system: bool
         created_at: datetime.datetime
         default_avatar: Asset
@@ -304,7 +304,6 @@ class Member(discord.abc.Messageable, _UserTag):
         self.pending: bool = data.get("pending", False)
         self._avatar: Optional[str] = data.get("avatar")
         self._guild_banner: Optional[str] = data.get("banner")
-        self.user_banner: Optional[Asset] = self._user.banner
 
     def __str__(self) -> str:
         return str(self._user)
@@ -554,7 +553,7 @@ class Member(discord.abc.Messageable, _UserTag):
         .. note::
             This information is only available via :meth:`Client.fetch_user`.
         """
-        return self.guild_banner or self.user_banner
+        return self.guild_banner or self._user.banner
 
     @property
     def guild_banner(self) -> Optional[Asset]:


### PR DESCRIPTION
<!-- Pull requests that do not fill this information in will likely be closed -->

## Summary

This PR adds support for the guild specific banner member's can have. This adds `Member.display_banner` to get the guild specific banner or the global banner.


**This is not available via the API yet or might never be therefore this is marked as draft for now.**

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
