### PR TITLE
Fix Guild.timed_out_members

### DIFF
--- a/discord/guild.py
+++ b/discord/guild.py
@@ -764,7 +764,7 @@ class Guild(Hashable):
 
         This works by checking if :attr:`Member.timeout_until` is not ``None``.
         """
-        return [member for member in self.members if member.timed_out is True]
+        return [member for member in self.members if member.timed_out]
 
     @property
     def humans(self) -> List[Member]:

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -764,7 +764,7 @@ class Guild(Hashable):
 
         This works by checking if :attr:`Member.timeout_until` is not ``None``.
         """
-        return [member for member in self.members if member.timeout_until is not None]
+        return [member for member in self.members if member.timed_out is True]
 
     @property
     def humans(self) -> List[Member]:

--- a/discord/member.py
+++ b/discord/member.py
@@ -370,6 +370,7 @@ class Member(discord.abc.Messageable, _UserTag):
         self.activities = member.activities
         self._state = member._state
         self._avatar = member._avatar
+        self.timeout_until = member.timeout_until
 
         # Reference will not be copied unless necessary by PRESENCE_UPDATE
         # See below
@@ -625,6 +626,14 @@ class Member(discord.abc.Messageable, _UserTag):
     def voice(self) -> Optional[VoiceState]:
         """Optional[:class:`VoiceState`]: Returns the member's current voice state."""
         return self.guild._voice_state_for(self._user.id)
+
+    @property
+    def timed_out(self) -> bool:
+        """:class:`bool`: Returns whether the member is timed out.
+
+        .. versionadded:: 2.0
+        """
+        return self.timeout_until is not None and self.timeout_until > utils.utcnow()
 
     async def ban(
         self,

--- a/discord/member.py
+++ b/discord/member.py
@@ -628,7 +628,7 @@ class Member(discord.abc.Messageable, _UserTag):
         return self.guild._voice_state_for(self._user.id)
 
     @property
-    def timed_out(self) -> bool:
+    def is_on_timeout(self) -> bool:
         """:class:`bool`: Returns whether the member is timed out.
 
         .. versionadded:: 2.0

--- a/discord/member.py
+++ b/discord/member.py
@@ -628,7 +628,7 @@ class Member(discord.abc.Messageable, _UserTag):
         return self.guild._voice_state_for(self._user.id)
 
     @property
-    def is_on_timeout(self) -> bool:
+    def timed_out(self) -> bool:
         """:class:`bool`: Returns whether the member is timed out.
 
         .. versionadded:: 2.0

--- a/discord/permissions.py
+++ b/discord/permissions.py
@@ -149,7 +149,7 @@ class Permissions(BaseFlags):
         """A factory method that creates a :class:`Permissions` with all
         permissions set to ``True``.
         """
-        return cls(0b111111111111111111111111111111111111111)
+        return cls(-1)
 
     @classmethod
     def all_channel(cls: Type[P]) -> P:

--- a/discord/permissions.py
+++ b/discord/permissions.py
@@ -149,7 +149,7 @@ class Permissions(BaseFlags):
         """A factory method that creates a :class:`Permissions` with all
         permissions set to ``True``.
         """
-        return cls(-1)
+        return cls(0b111111111111111111111111111111111111111)
 
     @classmethod
     def all_channel(cls: Type[P]) -> P:


### PR DESCRIPTION
<!-- Pull requests that do not fill this information in will likely be closed -->

## Summary

This fixes `Guild.timed_out_members` listing members that are not timed out anymore.

This also adds a new property to `Member` called `timed_out` this is an easy way to check whether the member is timed out or not.

`Special thanks to Chiggy#6420 (330810865312071700) for debugging.`
 
## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
