### PR TITLE
Fix `Permissions.all()`

### DIFF
--- a/discord/permissions.py
+++ b/discord/permissions.py
@@ -149,7 +149,7 @@ class Permissions(BaseFlags):
         """A factory method that creates a :class:`Permissions` with all
         permissions set to ``True``.
         """
-        return cls(-1)
+        return cls(0b11111111111111111111111111111111111111111)
 
     @classmethod
     def all_channel(cls: Type[P]) -> P:


### PR DESCRIPTION
Using `-1` here was a bad idea since it was breaking stuff.

<!-- Pull requests that do not fill this information in will likely be closed -->

## Summary

Fixes an issue where you wouldn't be able to create a role with `permissions=Permissions.all()`

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
