### PR TITLE
Add missing message flags

### DIFF
--- a/discord/flags.py
+++ b/discord/flags.py
@@ -295,6 +295,22 @@ class MessageFlags(BaseFlags):
         """
         return 64
 
+    @flag_value
+    def loading(self):
+        """:class:`bool`: Returns ``True`` if the source message is an interaction response and the bot is "thinking".
+
+        .. versionadded:: 2.0
+        """
+        return 128
+
+    @flag_value
+    def failed_to_mention_some_roles_in_thread(self):
+        """:class:`bool`: Returns ``True`` if the source message failed to mention some roles and add their members to the thread.
+
+        .. versionadded:: 2.0
+        """
+        return 256
+
 
 @fill_with_flags()
 class PublicUserFlags(BaseFlags):


### PR DESCRIPTION
## Summary

This adds `MessageFlags.loading` and `MessageFlags.failed_to_mention_some_roles_in_thread`.

`FAILED_TO_MENTION_SOME_ROLES_IN_THREAD` is a PR on the Discord API docs repo as [PR #4282](https://github.com/discord/discord-api-docs/pull/4282)

I can't find when the `LOADING` flag was added but it's in the API docs [here](https://discord.com/developers/docs/resources/channel#message-object-message-flags)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
