### PR TITLE
Add Thread.created_at

### DIFF
--- a/discord/threads.py
+++ b/discord/threads.py
@@ -55,6 +55,7 @@ if TYPE_CHECKING:
     from .role import Role
     from .permissions import Permissions
     from .state import ConnectionState
+    from datetime import datetime
 
 
 class Thread(Messageable, Hashable):
@@ -125,6 +126,10 @@ class Thread(Messageable, Hashable):
         Usually a value of 60, 1440, 4320 and 10080.
     archive_timestamp: :class:`datetime.datetime`
         An aware timestamp of when the thread's archived status was last updated in UTC.
+    created_at: Optional[:class:`datetime.datetime`]
+        Returns the thread's creation time in UTC. This is ``None`` for threads created before January 9, 2022.
+
+        .. versionadded:: 2.0
     """
 
     __slots__ = (
@@ -134,6 +139,7 @@ class Thread(Messageable, Hashable):
         "_type",
         "_state",
         "_members",
+        "_created_at",
         "owner_id",
         "parent_id",
         "last_message_id",
@@ -193,6 +199,7 @@ class Thread(Messageable, Hashable):
         self.archive_timestamp = parse_time(data["archive_timestamp"])
         self.locked = data.get("locked", False)
         self.invitable = data.get("invitable", True)
+        self._created_at = parse_time(data.get("create_timestamp"))
 
     def _update(self, data):
         try:
@@ -559,7 +566,7 @@ class Thread(Messageable, Hashable):
         invitable: bool = MISSING,
         slowmode_delay: int = MISSING,
         auto_archive_duration: ThreadArchiveDuration = MISSING,
-        reason: Optional[str] = None
+        reason: Optional[str] = None,
     ) -> Thread:
         """|coro|
 

--- a/discord/threads.py
+++ b/discord/threads.py
@@ -139,7 +139,7 @@ class Thread(Messageable, Hashable):
         "_type",
         "_state",
         "_members",
-        "_created_at",
+        "created_at",
         "owner_id",
         "parent_id",
         "last_message_id",
@@ -199,7 +199,7 @@ class Thread(Messageable, Hashable):
         self.archive_timestamp = parse_time(data["archive_timestamp"])
         self.locked = data.get("locked", False)
         self.invitable = data.get("invitable", True)
-        self._created_at = parse_time(data.get("create_timestamp"))
+        self.created_at = parse_time(data.get("create_timestamp"))
 
     def _update(self, data):
         try:


### PR DESCRIPTION


<!-- Pull requests that do not fill this information in will likely be closed -->

## Summary

This adds `Thread.created_at`. This was documented [here](https://github.com/discord/discord-api-docs/commit/53ee0109b874bde5ec2316379bf266bb332630a0).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
