### PR TITLE
add a discord_components check, raise an error if found

### DIFF
--- a/discord/__init__.py
+++ b/discord/__init__.py
@@ -75,6 +75,9 @@ logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 try:
     import discord_components
-    raise RuntimeError("package `discord_components` appears to be installed. Please uninstall it.")
+    raise RuntimeError("package `discord_components` appears to be installed. This library is incompatible with Enhanced-discord.py, "
+                       "Please use the built in Views.\n"
+                       "Documentation can be found here: https://enhanced-dpy.readthedocs.io/en/latest/api.html#bot-ui-kit\n"
+                       "Examples can be found here: https://github.com/iDevision/enhanced-discord.py/tree/2.0/examples/views")
 except ImportError:
     pass

--- a/discord/__init__.py
+++ b/discord/__init__.py
@@ -72,3 +72,9 @@ class VersionInfo(NamedTuple):
 version_info: VersionInfo = VersionInfo(major=2, minor=0, micro=0, releaselevel="alpha", serial=0)
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())
+
+try:
+    import discord_components
+    raise RuntimeError("package `discord_components` appears to be installed. Please uninstall it.")
+except ImportError:
+    pass


### PR DESCRIPTION
<!-- Pull requests that do not fill this information in will likely be closed -->

## Summary

<!-- What is this pull request for? Does it fix any issues? -->

This PR ensures that people do not use the `discord_components` package, as components are built in to the library.
With people complaining about about their install being broken with a root cause of `discord_components`, this check will ensure such cases do not happen.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
