### PR TITLE
Change default delete_message_days to 0

### DIFF
--- a/discord/guild.py
+++ b/discord/guild.py
@@ -2700,6 +2700,10 @@ class Guild(Hashable):
         delete_message_days: :class:`int`
             The number of days worth of messages to delete from the user
             in the guild. The minimum is 0 (default) and the maximum is 7.
+
+            .. versionchanged:: 2.0
+                The default value was changed from 1 to 0
+
         reason: Optional[:class:`str`]
             The reason the user got banned.
 

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -2682,7 +2682,7 @@ class Guild(Hashable):
         user: Snowflake,
         *,
         reason: Optional[str] = None,
-        delete_message_days: Literal[0, 1, 2, 3, 4, 5, 6, 7] = 1,
+        delete_message_days: Literal[0, 1, 2, 3, 4, 5, 6, 7] = 0,
     ) -> None:
         """|coro|
 
@@ -2699,7 +2699,7 @@ class Guild(Hashable):
             The user to ban from their guild.
         delete_message_days: :class:`int`
             The number of days worth of messages to delete from the user
-            in the guild. The minimum is 0 and the maximum is 7.
+            in the guild. The minimum is 0 (default) and the maximum is 7.
         reason: Optional[:class:`str`]
             The reason the user got banned.
 

--- a/discord/member.py
+++ b/discord/member.py
@@ -638,7 +638,7 @@ class Member(discord.abc.Messageable, _UserTag):
     async def ban(
         self,
         *,
-        delete_message_days: Literal[0, 1, 2, 3, 4, 5, 6, 7] = 1,
+        delete_message_days: Literal[0, 1, 2, 3, 4, 5, 6, 7] = 0,
         reason: Optional[str] = None,
     ) -> None:
         """|coro|


### PR DESCRIPTION


<!-- Pull requests that do not fill this information in will likely be closed -->

## Summary

The default of delete_message_days was set to 0 in the API docs [here](https://github.com/discord/discord-api-docs/commit/b7596e1fe02760f8a6b3866dcd38ab2812c3b8e5) and I feel like the library should follow them.

This might be a breaking change for some.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
