### PR TITLE
Add support for deferring in a Modal callback

### DIFF
--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -74,6 +74,7 @@ New Features
     - |commands| Add :meth:`Context.defer <.ext.commands.Context.defer>`
     - Add :class:`~ext.commands.Option`
 - Add ``delete_after`` kwarg to Interaction responses
+- Add ``thinking`` kwarg to :meth:`InteractionResponse.defer`
 - Update permissions
     - Add :attr:`Permissions.start_embedded_activities`
     - Add :attr:`Permissions.admin` as alias to :attr:`Permissions.administrator`


### PR DESCRIPTION
<!-- Pull requests that do not fill this information in will likely be closed -->

## Summary

This PR adds support for deferring a modal callback and adds a `thinking` that allows users to send the "thinking" status from a component (or modal), previously only supported for slash commands.

Needs testing on components


## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
